### PR TITLE
Refine README tone for senior profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </p>
 
 ## 🚀 About Me
-Full Stack Developer with expertise in building scalable microservices and cloud-native applications. Currently working on a banking platform, serving 100K+ daily users.
+Senior Full Stack Engineer specializing in architecting scalable, cloud-native platforms and high-availability services. I lead end-to-end delivery across distributed systems, from system design and data modeling to performance tuning and production operations. Currently delivering a banking platform that serves 100K+ daily users.
 
 ### 🎯 Current Focus
-- Building scalable microservices architectures
-- Cloud-native application development
-- High-performance distributed systems
-- Real-time data processing pipelines
+- Leading microservices architecture and platform evolution
+- Designing resilient, observable cloud-native systems
+- Optimizing performance for high-throughput workloads
+- Building reliable real-time data processing pipelines
 
 ## 💻 Tech Stack 
 


### PR DESCRIPTION
### Motivation
- Present the profile as a senior engineering leader by emphasizing ownership, system design, and production operations rather than individual contributor tasks.

### Description
- Rewrote the `## 🚀 About Me` section to highlight senior Full Stack Engineer responsibilities, end-to-end delivery across distributed systems, and production operations.
- Replaced the `### 🎯 Current Focus` bullets to emphasize leading microservices architecture, designing resilient and observable systems, and optimizing high-throughput performance.
- All edits were applied to `README.md` as content-only documentation updates.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819142f494832b8c7fe7c1f166f58c)